### PR TITLE
Add config to find correct webpack-dev-server url in gitpod

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,5 +1,22 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+const environment = require("./environment");
+const { merge } = require("webpack-merge");
 
-const environment = require('./environment')
+process.env.NODE_ENV = process.env.NODE_ENV || "development";
+const defaultConfig = environment.toWebpackConfig();
 
-module.exports = environment.toWebpackConfig()
+if (process.env.GITPOD_WORKSPACE_URL) {
+	const [protocol, hostname] = process.env.GITPOD_WORKSPACE_URL.split("://");
+
+	// ex: https://3035-fuchsia-lamprey-16r2m3h5.ws-us14.gitpod.io
+	const devServerPublic = `https://3035-${hostname}`;
+
+	const mergedConfig = merge(defaultConfig, {
+		devServer: {
+			public: devServerPublic,
+		},
+	});
+
+	module.exports = mergedConfig;
+} else {
+	module.exports = defaultConfig;
+}


### PR DESCRIPTION
Hi, @ghuntley

## Issue
In the current configuration, webpacker's **`webpack-dev-server` does not work properly**, therefore automatic browser refresh and HMR do not work. **_This is because the url of `webpack-dev-server`  is not specified correctly_** in gitpod.

This PR solves this problem by getting the url of `webpack-dev-server` automatically from gitpod url.

## Refs
https://github.com/gitpod-io/gitpod/issues/1881#issuecomment-719026824