### PR TITLE
Added config to run selenium and capybara e2e tests in gitpod.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,3 +6,30 @@ COPY --chown=gitpod:gitpod .ruby-version /tmp
 RUN echo "rvm_gems_path=/home/gitpod/.rvm" > ~/.rvmrc
 RUN bash -lc "rvm reinstall ruby-$(cat /tmp/.ruby-version) && rvm use ruby-$(cat /tmp/.ruby-version) --default && gem install rails"
 RUN echo "rvm_gems_path=/workspace/.rvm" > ~/.rvmrc
+
+# Install dependencies
+RUN sudo apt-get -q update \
+ && sudo apt-get install -y openjdk-8-jre-headless xvfb libxi6 libgconf-2-4 libnss3-dev \
+ && sudo rm -rf /var/lib/apt/lists/*
+
+# Install Chrome
+RUN sudo wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - \
+ && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list \
+ && sudo apt-get -y update \
+ && sudo apt-get -y install google-chrome-stable
+
+# Install ChromeDriver
+RUN CHROME_DRIVER_VERSION=`curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE` \
+ && sudo wget -N https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P ~/ \
+ && unzip ~/chromedriver_linux64.zip -d ~/ \
+ && sudo mv -f ~/chromedriver /usr/local/bin/chromedriver \
+ && sudo chown root:root /usr/local/bin/chromedriver \
+ && sudo chmod 0755 /usr/local/bin/chromedriver
+
+# Install Selenium
+RUN SELENIUM_STANDALONE_VERSION=3.9.1 \
+ && SELENIUM_SUBDIR=$(echo "$SELENIUM_STANDALONE_VERSION" | cut -d"." -f-2) \
+ && wget -N https://selenium-release.storage.googleapis.com/$SELENIUM_SUBDIR/selenium-server-standalone-$SELENIUM_STANDALONE_VERSION.jar -P ~/ \
+ && sudo mv -f ~/selenium-server-standalone-$SELENIUM_STANDALONE_VERSION.jar /usr/local/bin/selenium-server-standalone.jar \
+ && sudo chown root:root /usr/local/bin/selenium-server-standalone.jar \
+ && sudo chmod 0755 /usr/local/bin/selenium-server-standalone.jar

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,8 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end
+
+# Remove messy "Capybara starting Puma..." test logs
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Hi, @ghuntley

## Issue
Currently, **system tests by selenium cannot be run on gitpod**.

This is also reported in forum https://community.gitpod.io/t/how-to-run-a-selenium-test-on-gitpod/638/6

## PR
This PR added a config to run selenium and capybara system tests with `:headless_chrome`.

## How to check this PR
Start this branch with gitpod and run the following command.

```sh
rails g scaffold Post title content
rails db:migrate
rails test:system
```

If you can run the system test, it is working correctly.


## Refs
This code is from @thibaudgg's [this repository](https://github.com/mas-rad/todomvc-rails-2020) and [this PR](https://github.com/mas-rad/todomvc-rails-2020/commit/1c50ea9bab6ee8b52d94dcf7b46f6bc6e8edb47d) .

**I have removed some code** from the above code, leaving only the minimum required settings for running system test, but I may have removed some necessary code. **I am a linux newbie so I would appreciate if you could review it.**

Also, the docker config file for this repository may refer to [this gist](https://gist.github.com/ziadoz/3e8ab7e944d02fe872c3454d17af31a5).

Thanks 👍 
